### PR TITLE
Use pagination parameters from SerpApi instead of calculating on the client

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+exclude =
+    build
+    dist
+    .git
+    .env
+    .pytest_cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,11 +11,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -23,18 +22,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      run: make install build_dep
+
     - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      run: make lint
+
     - name: Test with pytest
-      run: pytest
+      run: make test
       env:
         API_KEY: ${{secrets.API_KEY}}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,14 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
 
     - name: Install dependencies
       run: make install build_dep

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ build/
 google_search_results.egg-info/PKG-INFO
 google_search_results.egg-info/SOURCES.txt
 
+# Python virtual environment
 .env

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ example:
 	pytest -s "tests/test_example.py::TestExample::test_async"
 
 build_dep:
-	pip3 install -U setuptools
+	pip3 install -U setuptools pytest
 
 # https://packaging.python.org/tutorials/packaging-projects/
 build:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ version=$(shell grep version setup.py | cut -d"'" -f2)
 
 .PHONY: build
 
-all: clean install test test2
+all: clean install lint test
 
 clean:
 	find . -name '*.pyc' -delete
@@ -13,7 +13,14 @@ clean:
 	pip3 uninstall google_search_results
 
 install:
-	pip3 install -r requirements.txt
+	python3 -m pip install --upgrade pip
+	if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+
+lint:
+	# stop the build if there are Python syntax errors or undefined names
+	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # Test with Python 3
 test:
@@ -25,7 +32,7 @@ example:
 	pytest -s "tests/test_example.py::TestExample::test_async"
 
 build_dep:
-	pip3 install -U setuptools pytest
+	pip3 install -U setuptools pytest flake8
 
 # https://packaging.python.org/tutorials/packaging-projects/
 build:

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,23 @@ clean:
 	find . -type d -name "__pycache__" -delete
 	pip3 uninstall google_search_results
 
+create_env:
+	python -m venv .env
+	source .env/bin/activate
+
 install:
 	python3 -m pip install --upgrade pip
 	if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
 
-lint:
+lint: build_dep
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # Test with Python 3
-test:
-	pytest
+test: build_dep
+	pytest --workers auto --tests-per-worker auto
 
 # run example only 
 #  and display output (-s)
@@ -32,7 +36,7 @@ example:
 	pytest -s "tests/test_example.py::TestExample::test_async"
 
 build_dep:
-	pip3 install -U setuptools pytest flake8
+	pip3 install -U setuptools pytest py pytest-parallel flake8
 
 # https://packaging.python.org/tutorials/packaging-projects/
 build:

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ If it's a client error, then a SerpApiClientException is raised.
    - youtube
    - walmart
    - apple_app_store
-   - naver 
+   - naver
  - raise SerpApiClientException instead of raw string in order to follow Python guideline 3.5+
  - add more unit error tests for serp_api_client
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the [playground to generate your code.](https://serpapi.com/playground)
   - [Quick start](#quick-start)
   - [Summary](#summary)
     - [Google Search API capability](#google-search-api-capability)
-    - [How to set SERP API key](#how-to-set-serp-api-key)
+    - [How to set SerpApi key](#how-to-set-serp-api-key)
     - [Example by specification](#example-by-specification)
     - [Location API](#location-api)
     - [Search Archive API](#search-archive-api)
@@ -106,7 +106,7 @@ params = {
   "safe": "Safe Search Flag",
   "num": "Number of Results",
   "start": "Pagination Offset",
-  "api_key": "Your SERP API Key", 
+  "api_key": "Your SerpApi Key", 
   # To be match
   "tbm": "nws|isch|shop", 
   # To be search
@@ -135,7 +135,7 @@ object_result = search.get_object()
 
 see below for more hands on examples.
 
-### How to set SERP API key
+### How to set SerpApi key
 
 You can get an API key here if you don't already have one: https://serpapi.com/users/sign_up
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Quick start
 
 This example runs a search about "coffee" using your secret api key.
 
-The Serp API service (backend)
+The SerpApi service (backend)
 
 * searches on Google using the query: q = "coffee"
 * parses the messy HTML responses
@@ -44,7 +44,7 @@ The Serp API service (backend)
 The GoogleSearch class
 
 * Format the request
-* Execute GET http request against Serp API service
+* Execute GET http request against SerpApi service
 * Parse JSON response into a dictionary
 
 Et voila..

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
+-i https://pypi.org/simple
+certifi==2022.5.18
+chardet==4.0.0
+-e .
+idna==2.10
 requests==2.25.1
+urllib3==1.26.9

--- a/serpapi/constant.py
+++ b/serpapi/constant.py
@@ -1,8 +1,9 @@
 
 # Pagination constant
 DEFAULT_START = 0
-DEFAULT_END = 100
+DEFAULT_END = 1000000000
 DEFAULT_PAGE_SIZE = 10
+DEFAULT_LIMIT = 1000
 
 # Supported earch engine
 GOOGLE_ENGINE = 'google'

--- a/serpapi/pagination.py
+++ b/serpapi/pagination.py
@@ -48,14 +48,16 @@ class Pagination:
 
     # stop if no next page
     if not 'next' in pagination:
-        raise StopIteration
+      raise StopIteration
 
     # Get actual parameters from next page of target website
-    params_from_target_website = dict(parse.parse_qsl(parse.urlsplit(pagination['next']).query))
+    params_from_target_website = dict(
+      parse.parse_qsl(parse.urlsplit(pagination['next']).query)
+    )
 
     # stop if parameters from the target website were not changed
     if params_from_target_website.items() <= self.client.params_dict.items():
-        raise StopIteration
+      raise StopIteration
 
     self.client.params_dict.update(params_from_target_website)
 

--- a/serpapi/pagination.py
+++ b/serpapi/pagination.py
@@ -54,7 +54,7 @@ class Pagination:
     params_from_target_website = dict(parse.parse_qsl(parse.urlsplit(pagination['next']).query))
 
     # stop if parameters from the target website were not changed
-    if params_from_target_website == self.client.params_dict:
+    if params_from_target_website.items() <= self.client.params_dict.items():
         raise StopIteration
 
     self.client.params_dict.update(params_from_target_website)

--- a/serpapi/pagination.py
+++ b/serpapi/pagination.py
@@ -1,58 +1,48 @@
 from urllib import parse
-from serpapi.serp_api_client_exception import SerpApiClientException
+from serpapi import constant
 
-DEFAULT_START = 0 
-DEFAULT_END = 1000000000
-DEFAULT_num = 10
-
-# Paginate response in SearpApi
+# Paginate response in SerpApi
 class Pagination:
-  
-  def __init__(self, client, start = DEFAULT_START, end = DEFAULT_END, num = DEFAULT_num):
-    # serp api client
+
+  def __init__(self, client, start = constant.DEFAULT_START, end = constant.DEFAULT_END, num = constant.DEFAULT_PAGE_SIZE, limit = constant.DEFAULT_LIMIT):
+    # SerpApi client
     self.client = client
-    # range
-    # self.start = start
-    # self.end = end
-    # self.num = num
 
-    # # use value from the client
-    # if self.start == DEFAULT_START:
-    #   if 'start' in self.client.params_dict:
-    #     self.start = self.client.params_dict['start']
-    # if self.end == DEFAULT_END:
-    #   if 'end' in self.client.params_dict:
-    #     self.end = self.client.params_dict['end']
-    # if self.num == DEFAULT_num:
-    #   if 'num' in self.client.params_dict:
-    #     self.num = self.client.params_dict['num']
+    self.limit = limit
 
-    # # basic check
-    # if self.start > self.end:
-    #     raise SerpApiClientException("start: {} must be less than end: {}".format(self.start, self.end))
-    # if(self.start + self.num) > self.end:
-    #     raise SerpApiClientException("start + num: {} + {} must be less than end: {}".format(self.start, self.num, self.end))
+    """Backwards-compatible workaround.
+    `start`, `num`, and `end` parameters to `Pagination#__init__` are deprecated.
+
+    Set `start` and `num` search parameters.
+    It works for Google Search API only.
+    A correct way to set an offset, limit, and page size is in search parameters directly.
+    (A hash that is passed to `SerpApi#__init__`.)
+    """
+    if start != constant.DEFAULT_START:
+      self.client.params_dict['start'] = start
+
+    if end != constant.DEFAULT_END:
+      self.client.params_dict['end'] = end
+
+    if num != constant.DEFAULT_PAGE_SIZE:
+      self.client.params_dict['num'] = num
+
+
+    self.page_number = 0
 
   def __iter__(self):
-    # self.update()
     return self
 
-  # def update(self):
-  #   self.client.params_dict['start'] = self.start
-  #   self.client.params_dict['num'] = self.num
-  #   if self.start > 0:
-  #     self.client.params_dict['start'] += 1
-
   def __next__(self):
-    # update parameter
-    # self.update()
+    if self.page_number >= self.limit:
+      raise StopIteration
 
     # execute request
     result = self.client.get_dict()
 
     pagination = result.get('serpapi_pagination', result.get('pagination'))
 
-    # stop if backend miss to return serpapi_pagination
+    # stop if backend miss to return `serpapi_pagination` or `pagination`
     if not pagination:
       raise StopIteration
 
@@ -69,11 +59,6 @@ class Pagination:
 
     self.client.params_dict.update(params_from_target_website)
 
-    # ends if no next page
-    # if self.start + self.num > self.end:
-    #     raise StopIteration
-    # 
-    # # increment start page
-    # self.start += self.num
+    self.page_number += 1
 
     return result

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -1,17 +1,9 @@
 import requests
 import json
+from serpapi.constant import *
 from serpapi.pagination import Pagination
 from serpapi.serp_api_client_exception import SerpApiClientException
 
-GOOGLE_ENGINE = 'google'
-BING_ENGINE = 'bing'
-BAIDU_ENGINE = 'baidu'
-GOOGLE_SCHOLAR_ENGINE = 'google_scholar'
-YANDEX_ENGINE = 'yandex'
-EBAY_ENGINE = 'ebay'
-YAHOO_ENGINE = 'yahoo'
-HOME_DEPOT_ENGINE = 'home_depot'
-YOUTUBE_ENGINE = 'youtube'
 
 class SerpApiClient(object):
     """SerpApiClient enables to query any search engines supported by SerpApi and parse the results.
@@ -170,8 +162,8 @@ class SerpApiClient(object):
         buffer = self.get_results('/locations.json')
         return json.loads(buffer)
     
-    def pagination(self, start = 0, end = 1000000000, page_size = 10):
+    def pagination(self, start = DEFAULT_START, end = DEFAULT_END, page_size = DEFAULT_PAGE_SIZE, limit = DEFAULT_LIMIT):
         """Return:
             Generator to iterate the search results pagination
         """
-        return Pagination(self, start, end, page_size)
+        return Pagination(self, start, end, page_size, limit)

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -63,7 +63,7 @@ class SerpApiClient(object):
 
     def get_html(self):
         """Returns:
-            Raw HTML search result from Gooogle
+            Raw HTML search result from Google
         """
         return self.get_results()
 

--- a/tests/test_apple_app_store_search.py
+++ b/tests/test_apple_app_store_search.py
@@ -22,5 +22,22 @@ class TestAppleAppStoreSearch(unittest.TestCase):
 				pp.pprint(data)
 				print(data.keys())
 
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 20
+				search = AppleAppStoreSearch({"term": "Coffee", "page": 0, "num": page_size})
+
+				limit = 4
+				pages = search.pagination(limit=limit)
+
+				page_count = 0
+				result_count = 0
+
+				for page in pages:
+					page_count += 1
+					result_count += len(page["organic_results"])
+
+				self.assertEqual(page_count, limit)
+
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_baidu_search.py
+++ b/tests/test_baidu_search.py
@@ -21,5 +21,22 @@ class TestBaiduSearchApi(unittest.TestCase):
 				pp = pprint.PrettyPrinter(indent=2)
 				pp.pprint(data)
 
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 30
+				search = BaiduSearch({"q": "Coffee", "pn": 10, "m": page_size})
+
+				limit = 3
+				pages = search.pagination(limit=limit)
+
+				page_count = 0
+				result_count = 0
+
+				for page in pages:
+					page_count += 1
+					result_count += len(page["organic_results"])
+
+				self.assertEqual(page_count, limit)
+
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_bing_search.py
+++ b/tests/test_bing_search.py
@@ -21,5 +21,22 @@ class TestBingSearchApi(unittest.TestCase):
 				# pp = pprint.PrettyPrinter(indent=2)
 				# pp.pprint(data)
 
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 20
+				search = BingSearch({"q": "Coffee", "location": "Austin,Texas", "first": 10, "count": page_size})
+
+				limit = 4
+				pages = search.pagination(limit=limit)
+
+				page_count = 0
+				result_count = 0
+
+				for page in pages:
+					page_count += 1
+					result_count += len(page["organic_results"])
+
+				self.assertEqual(page_count, limit)
+
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_duck_duck_go_search.py
+++ b/tests/test_duck_duck_go_search.py
@@ -4,12 +4,12 @@ import os
 import pprint
 from serpapi import DuckDuckGoSearch
 
+@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 class TestDuckDuckGoSearch(unittest.TestCase):
 
 		def setUp(self):
 				DuckDuckGoSearch.SERP_API_KEY = os.getenv("API_KEY", "demo")
 
-		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_json(self):
 				search = DuckDuckGoSearch({"q": "Coffee"})
 				data = search.get_json()
@@ -25,7 +25,6 @@ class TestDuckDuckGoSearch(unittest.TestCase):
 				# pp.pprint(data)
 				self.assertTrue(len(data.keys()) > 3)
 
-		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_paginate_page_size(self):
 				limit = 3
 

--- a/tests/test_duck_duck_go_search.py
+++ b/tests/test_duck_duck_go_search.py
@@ -47,16 +47,16 @@ class TestDuckDuckGoSearch(unittest.TestCase):
 				page_count += 1
 
 				for organic_results in page.get("organic_results", []):
-						count += 1
-						i = 0
+					count += 1
+					i = 0
 
-						for t in titles:
-							i += 1
+					for t in titles:
+						i += 1
 
-							if t == organic_results.get('title'):
-								print(f"{count} duplicated title: {t} at index: {i}")
+						if t == organic_results.get('title'):
+							print(f"{count} duplicated title: {t} at index: {i}")
 
-						titles.append(organic_results['title'])
+					titles.append(organic_results['title'])
 
 				self.assertEqual(count % 2, 0, f"page {page_count} does not contain 20 elements")
 

--- a/tests/test_duck_duck_go_search.py
+++ b/tests/test_duck_duck_go_search.py
@@ -17,51 +17,46 @@ class TestDuckDuckGoSearch(unittest.TestCase):
 				self.assertEqual(data["search_metadata"]["status"], "Success")
 				self.assertIsNotNone(data["search_metadata"]["duckduckgo_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
-				if "organic_results" in data:
-					self.assertIsNotNone(data["organic_results"][1]["title"])
+
+				for organic_result in data.get("organic_results", []):
+						self.assertIsNotNone(organic_result.get("title"))
+
 				# pp = pprint.PrettyPrinter(indent=2)
 				# pp.pprint(data)
 				self.assertTrue(len(data.keys()) > 3)
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_paginate_page_size(self):
-			start = 10
-			limit = 3
+				limit = 3
 
-			# use parameters in
-			params = {
-				"q": "coca cola",
-				"api_key": os.getenv("API_KEY"),
-				"start": start,
-			}
+				params = {
+					"q": "coffee",
+				}
 
-			titles = []
+				titles = []
 
-			search = DuckDuckGoSearch(params)
-			pages = search.pagination(limit=limit)
+				search = DuckDuckGoSearch(params)
+				pages = search.pagination(limit=limit)
 
-			page_count = 0
-			count = 0
+				page_number = 0
+				count = 0
 
-			for page in pages:
-				page_count += 1
+				for page in pages:
+					page_number += 1
 
-				for organic_results in page.get("organic_results", []):
-					count += 1
-					i = 0
+					for organic_results in page.get("organic_results", []):
+						count += 1
+						title_index = 0
 
-					for t in titles:
-						i += 1
+						for title in titles:
+							title_index += 1
 
-						if t == organic_results.get('title'):
-							print(f"{count} duplicated title: {t} at index: {i}")
+							if title == organic_results.get('title'):
+								print("%d duplicated title: %s at index: %d" % (count, title, title_index))
 
-					titles.append(organic_results['title'])
+						titles.append(organic_results['title'])
 
-				self.assertEqual(count % 2, 0, f"page {page_count} does not contain 20 elements")
-
-			# check number of pages match
-			self.assertEqual(page_count, limit)
+				self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 
 
 if __name__ == '__main__':

--- a/tests/test_duck_duck_go_search.py
+++ b/tests/test_duck_duck_go_search.py
@@ -23,5 +23,46 @@ class TestDuckDuckGoSearch(unittest.TestCase):
 				# pp.pprint(data)
 				self.assertTrue(len(data.keys()) > 3)
 
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate_page_size(self):
+			start = 10
+			limit = 3
+
+			# use parameters in
+			params = {
+				"q": "coca cola",
+				"api_key": os.getenv("API_KEY"),
+				"start": start,
+			}
+
+			titles = []
+
+			search = DuckDuckGoSearch(params)
+			pages = search.pagination(limit=limit)
+
+			page_count = 0
+			count = 0
+
+			for page in pages:
+				page_count += 1
+
+				for organic_results in page.get("organic_results", []):
+						count += 1
+						i = 0
+
+						for t in titles:
+							i += 1
+
+							if t == organic_results.get('title'):
+								print(f"{count} duplicated title: {t} at index: {i}")
+
+						titles.append(organic_results['title'])
+
+				self.assertEqual(count % 2, 0, f"page {page_count} does not contain 20 elements")
+
+			# check number of pages match
+			self.assertEqual(page_count, limit)
+
+
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_ebay_search.py
+++ b/tests/test_ebay_search.py
@@ -18,6 +18,10 @@ class TestEbaySearchApi(unittest.TestCase):
 				self.assertIsNotNone(data["search_metadata"]["ebay_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
 				self.assertIsNotNone(data["organic_results"][0]["title"])
+
+				for organic_result in data.get("organic_results", []):
+						self.assertIsNotNone(organic_result.get("title"))
+
 				# pp = pprint.PrettyPrinter(indent=2)
 				# pp.pprint(data)
 

--- a/tests/test_ebay_search.py
+++ b/tests/test_ebay_search.py
@@ -21,22 +21,30 @@ class TestEbaySearchApi(unittest.TestCase):
 				# pp = pprint.PrettyPrinter(indent=2)
 				# pp.pprint(data)
 
-    # TODO fix universal pagination
-		@unittest.skipIf((os.getenv("DEBUGAPI_KEY") == None), "no api_key provided")
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_paginate(self):
+			page_size = 60
+
 			params = {
 				"_nkw": "coffee",
-				"api_key": os.getenv("API_KEY")
+				"api_key": os.getenv("API_KEY"),
+				"_ipg": page_size,
 			}
+
 			search = EbaySearch(params)
-			pages = search.pagination(20, 60)
+
+			limit = 3
+			pages = search.pagination(limit = limit)
+
 			page_count = 0
 			result_count = 0
+
 			for page in pages:
 				page_count += 1
 				result_count += len(page["organic_results"])
-			self.assertEqual(page_count, 2)
-			self.assertEqual(page_count, 40)
+
+			self.assertEqual(page_count, limit)
+			self.assertEqual(result_count, page_size * limit)
 
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_ebay_search.py
+++ b/tests/test_ebay_search.py
@@ -31,7 +31,6 @@ class TestEbaySearchApi(unittest.TestCase):
 
 			params = {
 				"_nkw": "coffee",
-				"api_key": os.getenv("API_KEY"),
 				"_ipg": page_size,
 			}
 

--- a/tests/test_example_paginate.py
+++ b/tests/test_example_paginate.py
@@ -41,7 +41,7 @@ class TestExamplePaginate(unittest.TestCase):
       # total number pages expected
       #  the exact number if variable depending on the search engine backend
       self.assertEqual(page_count, limit)
-      self.assertEqual(len(title), 20, "number of search results")
+      # self.assertEqual(len(title), 20, "number of search results")
       #self.assertEqual(len(set(title)), len(title), "duplicated elements detected")
 
     @unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
@@ -86,10 +86,9 @@ class TestExamplePaginate(unittest.TestCase):
             #print(f"{count} - title: {news_result['title']}")
             title.append(news_result['title'])
 
-        self.assertEqual(count%2, 0, ("page %s does not contain 20 elements" % page_count))
+        self.assertEqual(count%2, 0, f"page {page_count} does not contain {page_size} elements")
       
       # check number of pages match
       self.assertEqual(page_count, limit)
-      self.assertEqual(len(title), end, "number of search results")
       # google randomly duplicated search result
       # self.assertEqual(len(set(title)), end, "duplicated search results")

--- a/tests/test_example_paginate.py
+++ b/tests/test_example_paginate.py
@@ -86,8 +86,8 @@ class TestExamplePaginate(unittest.TestCase):
             #print(f"{count} - title: {news_result['title']}")
             title.append(news_result['title'])
 
-        self.assertEqual(count%2, 0, f"page {page_count} does not contain {page_size} elements")
-      
+        self.assertEqual(page_count, limit, "Number of pages doesn't match.")
+
       # check number of pages match
       self.assertEqual(page_count, limit)
       # google randomly duplicated search result

--- a/tests/test_example_paginate.py
+++ b/tests/test_example_paginate.py
@@ -8,8 +8,7 @@ class TestExamplePaginate(unittest.TestCase):
     @unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
     def test_paginate(self):
       # to get 2 pages
-      start = 0
-      end = 20
+      limit = 2
       # basic search parameters
       params = {
         "q": "coca cola",
@@ -19,33 +18,40 @@ class TestExamplePaginate(unittest.TestCase):
       # as proof of concept 
       #  title collects
       title = []
+
       # initialize a search
       search = GoogleSearch(params)
+
       # create a python generator
-      pages = search.pagination(start, end)
+      pages = search.pagination(limit=limit)
       # fetch one search result per iteration 
       #  using a basic python for loop 
       #   which invokes python iterator under the hood.
+
       page_count = 0
+
       for page in pages:
         page_count += 1
         #print(f"Current page: {page['serpapi_pagination']['current']}")
         for news_result in page["news_results"]:
             #print(f"Title: {news_result['title']}\nLink: {news_result['link']}\n")
             title.append(news_result['title'])
+
       # double check if things adds up.
       # total number pages expected
       #  the exact number if variable depending on the search engine backend
-      self.assertEqual(page_count, 2)
+      self.assertEqual(page_count, limit)
       self.assertEqual(len(title), 20, "number of search results")
       #self.assertEqual(len(set(title)), len(title), "duplicated elements detected")
 
     @unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
     def test_paginate_page_size(self):
-      # to get 2 pages with each page contains 20 search results
+      # to get 4 pages with each page contains 20 search results
       start = 0
       end = 80
       page_size = 20
+
+      limit = (end - start) / page_size
 
       # use parameters in
       params = {
@@ -56,12 +62,17 @@ class TestExamplePaginate(unittest.TestCase):
         "end": end,
         "num": page_size
       }
+
       title = []
+
       search = GoogleSearch(params)
-      # parameter start,end,page_size will be used instead of pagination
-      pages = search.pagination()
+
+      # parameter limit will be used instead of pagination
+      pages = search.pagination(limit=limit)
+
       page_count = 0
       count = 0
+
       for page in pages:
         page_count += 1
         # print(f"Current page: {page['serpapi_pagination']['current']}")
@@ -78,7 +89,7 @@ class TestExamplePaginate(unittest.TestCase):
         self.assertEqual(count%2, 0, ("page %s does not contain 20 elements" % page_count))
       
       # check number of pages match
-      self.assertEqual(page_count, 4)
+      self.assertEqual(page_count, limit)
       self.assertEqual(len(title), end, "number of search results")
       # google randomly duplicated search result
       # self.assertEqual(len(set(title)), end, "duplicated search results")

--- a/tests/test_example_paginate.py
+++ b/tests/test_example_paginate.py
@@ -86,9 +86,7 @@ class TestExamplePaginate(unittest.TestCase):
             #print(f"{count} - title: {news_result['title']}")
             title.append(news_result['title'])
 
-        self.assertEqual(page_count, limit, "Number of pages doesn't match.")
-
       # check number of pages match
-      self.assertEqual(page_count, limit)
+      self.assertEqual(page_count, limit, "Number of pages doesn't match.")
       # google randomly duplicated search result
       # self.assertEqual(len(set(title)), end, "duplicated search results")

--- a/tests/test_google_scholar_search_api.py
+++ b/tests/test_google_scholar_search_api.py
@@ -18,5 +18,21 @@ class TestGoogleScholarSearch(unittest.TestCase):
 				self.assertIsNotNone(data["search_metadata"]["id"])
 				self.assertIsNotNone(data["organic_results"][0]["title"])
 
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 20
+				search = GoogleScholarSearch({"q": "Coffee", "start": 10, "num": page_size})
+
+				limit = 3
+				pages = search.pagination(limit=limit)
+				page_count = 0
+				result_count = 0
+
+				for page in pages:
+						page_count += 1
+						result_count += len(page["organic_results"])
+
+				self.assertEqual(page_count, limit)
+
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_google_search.py
+++ b/tests/test_google_search.py
@@ -12,15 +12,18 @@ class TestSearchApi(unittest.TestCase):
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_paginate(self):
-				search = GoogleSearch({"q": "Coffee", "location": "Austin,Texas"})
-				pages = search.pagination(0, 20, 10)
-				urls = []
+				page_size = 20
+				search = GoogleSearch({"q": "Coffee", "location": "Austin,Texas", "start": 10, "num": page_size})
+
+				limit = 2
+				pages = search.pagination(limit=limit)
+
+				page_count = 0
+
 				for page in pages:
-					urls.append(page['serpapi_pagination']['next'])
-				self.assertEqual(len(urls), 2)
-				self.assertTrue("start=10" in urls[0])
-				print(urls[1])
-				self.assertTrue("start=21" in urls[1])
+					page_count += 1
+
+				self.assertEqual(page_count, limit)
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_json(self):
@@ -36,7 +39,9 @@ class TestSearchApi(unittest.TestCase):
 		def test_get_json(self):
 				search = GoogleSearch({"q": "Coffee", "engine": "google_scholar"})
 				data = search.get_json()
-				self.assertIsNotNone(data["organic_results"][0]["title"])
+
+				for organic_result in data["organic_results"]:
+					self.assertIsNotNone(organic_result["title"])
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_dict(self):

--- a/tests/test_home_depot_search.py
+++ b/tests/test_home_depot_search.py
@@ -18,7 +18,9 @@ class TestHomeDepotSearchApi(unittest.TestCase):
 				self.assertIsNotNone(data["search_metadata"]["home_depot_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
 				self.assertTrue(len(data["products"]) > 5)
-				self.assertIsNotNone(data["products"][0]["title"])
+
+				for product in data.get("products", []):
+					self.assertIsNotNone(product["title"])
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_object(self):
@@ -32,6 +34,43 @@ class TestHomeDepotSearchApi(unittest.TestCase):
 				self.assertEqual(data.search_parameters.q, "chair")
 				self.assertEqual(data.search_parameters.engine, "home_depot")
 				self.assertGreater(data.search_information.total_results, 10)
+
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate_page_size(self):
+			start = 24
+			limit = 3
+
+			# use parameters in
+			params = {
+				"q": "chair",
+				"api_key": os.getenv("API_KEY"),
+				"start": start,
+			}
+
+			titles = []
+
+			search = HomeDepotSearch(params)
+			pages = search.pagination(limit=limit)
+
+			page_number = 0
+			count = 0
+
+			for page in pages:
+				page_number += 1
+
+				for product in page.get("products", []):
+					count += 1
+					i = 0
+
+					for t in titles:
+						i += 1
+
+						if t == product.get('title'):
+							print(f"{count} duplicated title: {t} at index: {i}")
+
+					titles.append(product['title'])
+
+			self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_home_depot_search.py
+++ b/tests/test_home_depot_search.py
@@ -42,8 +42,7 @@ class TestHomeDepotSearchApi(unittest.TestCase):
 
 			# use parameters in
 			params = {
-				"q": "chair",
-				"api_key": os.getenv("API_KEY"),
+				"q": "coffee",
 				"start": start,
 			}
 
@@ -66,7 +65,7 @@ class TestHomeDepotSearchApi(unittest.TestCase):
 						i += 1
 
 						if t == product.get('title'):
-							print(f"{count} duplicated title: {t} at index: {i}")
+							print("%d duplicated title: %s at index: %d" % (count, t, i))
 
 					titles.append(product['title'])
 

--- a/tests/test_naver_search.py
+++ b/tests/test_naver_search.py
@@ -17,11 +17,53 @@ class TestNaverSearchApi(unittest.TestCase):
 				self.assertEqual(data["search_metadata"]["status"], "Success")
 				self.assertIsNotNone(data["search_metadata"]["naver_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
-				if "ads_results" in data:
-					self.assertIsNotNone(data["ads_results"][1]["title"])
+
+				for ad in data.get("ads_results", []):
+					self.assertIsNotNone(ad["title"])
+
+				for organic_result in data.get("web_results", []):
+					self.assertIsNotNone(organic_result["title"])
+
 				pp = pprint.PrettyPrinter(indent=2)
 				pp.pprint(data)
 				print(data.keys())
+
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate_page_size(self):
+			start = 24
+			limit = 3
+
+			# use parameters in
+			params = {
+				"query": "coffee",
+				"api_key": os.getenv("API_KEY"),
+				"start": start,
+			}
+
+			titles = []
+
+			search = NaverSearch(params)
+			pages = search.pagination(limit=limit)
+
+			page_number = 0
+			count = 0
+
+			for page in pages:
+				page_number += 1
+
+				for result in page.get("web_results", []):
+					count += 1
+					i = 0
+
+					for item in titles:
+						i += 1
+
+						if item == result.get('title'):
+							print(f"{count} duplicated title: {item} at index: {i}")
+
+					titles.append(result['title'])
+
+			self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_naver_search.py
+++ b/tests/test_naver_search.py
@@ -36,7 +36,6 @@ class TestNaverSearchApi(unittest.TestCase):
 			# use parameters in
 			params = {
 				"query": "coffee",
-				"api_key": os.getenv("API_KEY"),
 				"start": start,
 			}
 
@@ -59,7 +58,7 @@ class TestNaverSearchApi(unittest.TestCase):
 						i += 1
 
 						if item == result.get('title'):
-							print(f"{count} duplicated title: {item} at index: {i}")
+							print("%d duplicated title: %s at index: %d" % (count, item, i))
 
 					titles.append(result['title'])
 

--- a/tests/test_walmart_search.py
+++ b/tests/test_walmart_search.py
@@ -4,8 +4,8 @@ import os
 import pprint
 from serpapi import WalmartSearch
 
-class TestWalmartSearchApi(unittest.TestCase):
 
+class TestWalmartSearchApi(unittest.TestCase):
 		def setUp(self):
 				WalmartSearch.SERP_API_KEY = os.getenv("API_KEY", "demo")
 
@@ -17,11 +17,43 @@ class TestWalmartSearchApi(unittest.TestCase):
 				self.assertEqual(data["search_metadata"]["status"], "Success")
 				self.assertIsNotNone(data["search_metadata"]["walmart_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
-				if "organic_results" in data:
-					self.assertIsNotNone(data["organic_results"][1]["title"])
+
+				for organic_result in data.get("organic_results", []):
+						self.assertIsNotNone(organic_result.get("title"))
+
 				pp = pprint.PrettyPrinter(indent=2)
 				pp.pprint(data)
 				print(data.keys())
 
-if __name__ == '__main__':
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 50
+				search = WalmartSearch({"query": "Coffee", "page": 1, "ps": page_size})
+
+				limit = 4
+				pages = search.pagination(limit=limit)
+
+				product_ids = []
+				page_number = 0
+
+				for page in pages:
+						organic_results_count = 0
+						page_number += 1
+
+						for organic_result in page.get("organic_results", []):
+								organic_results_count += 1
+								product_id_index = 0
+
+								for id in product_ids:
+										product_id_index += 1
+
+										if id == organic_result.get("product_id"):
+												print(f"{organic_results_count} duplicated product_id: {id} at index: {product_id_index}")
+
+								product_ids.append(organic_result.get("product_id"))
+
+				self.assertEqual(page_number, limit, "Number of pages doesn't match.")
+
+
+if __name__ == "__main__":
 		unittest.main()

--- a/tests/test_walmart_search.py
+++ b/tests/test_walmart_search.py
@@ -27,8 +27,8 @@ class TestWalmartSearchApi(unittest.TestCase):
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_paginate(self):
-				page_size = 50
-				search = WalmartSearch({"query": "Coffee", "page": 1, "ps": page_size})
+				page_size = 40
+				search = WalmartSearch({"query": "coffee", "ps": page_size})
 
 				limit = 4
 				pages = search.pagination(limit=limit)
@@ -48,7 +48,7 @@ class TestWalmartSearchApi(unittest.TestCase):
 										product_id_index += 1
 
 										if id == organic_result.get("product_id"):
-												print(f"{organic_results_count} duplicated product_id: {id} at index: {product_id_index}")
+												print("%d duplicated product_id: %s at index: %d" % (organic_results_count, id, product_id_index))
 
 								product_ids.append(organic_result.get("product_id"))
 

--- a/tests/test_yahoo_search.py
+++ b/tests/test_yahoo_search.py
@@ -41,18 +41,18 @@ class TestYahooSearchApi(unittest.TestCase):
 								organic_results_count += 1
 								title_index = 0
 
-								for id in titles:
+								for title in titles:
 										title_index += 1
 
-										if id == organic_result.get("title"):
-												print(f"{organic_results_count} duplicated title: {id} at index: {title_index}")
+										if title == organic_result.get("title"):
+												print("%d duplicated title: %s at index: %d" % (organic_results_count, title, title_index))
 
 								titles.append(organic_result.get("title"))
 
 						self.assertEqual(
 								organic_results_count,
 								page_size,
-								f"page {page_number} does not contain {page_size} elements",
+								"page %d does not contain %d elements" % (page_number, page_size)
 						)
 
 				self.assertEqual(page_number, limit, "Number of pages doesn't match.")

--- a/tests/test_yahoo_search.py
+++ b/tests/test_yahoo_search.py
@@ -17,7 +17,45 @@ class TestYahooSearchApi(unittest.TestCase):
 				self.assertEqual(data["search_metadata"]["status"], "Success")
 				self.assertIsNotNone(data["search_metadata"]["yahoo_url"])
 				self.assertIsNotNone(data["search_metadata"]["id"])
-				self.assertIsNotNone(data["organic_results"][0]["title"])
+
+				for organic_result in data.get("organic_results", []):
+						self.assertIsNotNone(organic_result.get("title"))
+
+
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				page_size = 7
+				search = YahooSearch({"p": "Coffee", "b": page_size, "pz": page_size})
+
+				limit = 4
+				pages = search.pagination(limit=limit)
+
+				titles = []
+				page_number = 0
+
+				for page in pages:
+						organic_results_count = 0
+						page_number += 1
+
+						for organic_result in page.get("organic_results", []):
+								organic_results_count += 1
+								title_index = 0
+
+								for id in titles:
+										title_index += 1
+
+										if id == organic_result.get("title"):
+												print(f"{organic_results_count} duplicated title: {id} at index: {title_index}")
+
+								titles.append(organic_result.get("title"))
+
+						self.assertEqual(
+								organic_results_count,
+								page_size,
+								f"page {page_number} does not contain {page_size} elements",
+						)
+
+				self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_yahoo_search.py
+++ b/tests/test_yahoo_search.py
@@ -45,15 +45,9 @@ class TestYahooSearchApi(unittest.TestCase):
 										title_index += 1
 
 										if title == organic_result.get("title"):
-												print("%d duplicated title: %s at index: %d" % (organic_results_count, title, title_index))
+												print("Organic result #%d on page #%d contains duplicated title: %s at index: %d" % (organic_results_count, page_number, title, title_index))
 
 								titles.append(organic_result.get("title"))
-
-						self.assertEqual(
-								organic_results_count,
-								page_size,
-								"page %d does not contain %d elements" % (page_number, page_size)
-						)
 
 				self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 

--- a/tests/test_yandex_search.py
+++ b/tests/test_yandex_search.py
@@ -45,7 +45,7 @@ class TestYandexSearchApi(unittest.TestCase):
 										title_index += 1
 
 										if title == organic_result.get("title"):
-												print(f"{organic_results_count} duplicated title: {title} at index: {title_index}")
+												print("%d duplicated title: %s at index: %d" % (organic_results_count, title, title_index))
 
 								titles.append(organic_result.get("title"))
 

--- a/tests/test_yandex_search.py
+++ b/tests/test_yandex_search.py
@@ -19,7 +19,37 @@ class TestYandexSearchApi(unittest.TestCase):
 				self.assertIsNotNone(data["search_metadata"]["id"])
 				pp = pprint.PrettyPrinter(indent=2)
 				pp.pprint(data["organic_results"])
-				self.assertIsNotNone(data["organic_results"][1]["title"])
+
+				for organic_result in data.get("organic_results", []):
+						self.assertIsNotNone(organic_result.get("title"))
+
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				search = YandexSearch({"text": "Coffee"})
+
+				limit = 3
+				pages = search.pagination(limit=limit)
+
+				titles = []
+				page_number = 0
+
+				for page in pages:
+						organic_results_count = 0
+						page_number += 1
+
+						for organic_result in page.get("organic_results", []):
+								organic_results_count += 1
+								title_index = 0
+
+								for title in titles:
+										title_index += 1
+
+										if title == organic_result.get("title"):
+												print(f"{organic_results_count} duplicated title: {title} at index: {title_index}")
+
+								titles.append(organic_result.get("title"))
+
+				self.assertEqual(page_number, limit, "Number of pages doesn't match.")
 
 if __name__ == '__main__':
 		unittest.main()

--- a/tests/test_youtube_search.py
+++ b/tests/test_youtube_search.py
@@ -52,7 +52,7 @@ class TestYoutubeSearchApi(unittest.TestCase):
 										title_index += 1
 
 										if title == video_result.get("title"):
-												print(f"{count} duplicated title: {title} at index: {title_index}")
+												print("%d duplicated title: %s at index: %d" % (count, title, title_index))
 
 								titles.append(video_result.get("title"))
 

--- a/tests/test_youtube_search.py
+++ b/tests/test_youtube_search.py
@@ -4,8 +4,8 @@ import os
 import pprint
 from serpapi import YoutubeSearch
 
-class TestYoutubeSearchApi(unittest.TestCase):
 
+class TestYoutubeSearchApi(unittest.TestCase):
 		def setUp(self):
 				YoutubeSearch.SERP_API_KEY = os.getenv("API_KEY", "demo")
 
@@ -29,5 +29,35 @@ class TestYoutubeSearchApi(unittest.TestCase):
 				self.assertEqual(data.search_parameters.engine, "youtube")
 				self.assertGreater(data.search_information.total_results, 10)
 
-if __name__ == '__main__':
+		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
+		def test_paginate(self):
+				search = YoutubeSearch({"search_query": "chair"})
+
+				limit = 3
+				pages = search.pagination(limit=limit)
+
+				titles = []
+
+				page_count = 0
+				count = 0
+
+				for page in pages:
+						page_count += 1
+
+						for video_result in page.get("video_results", []):
+								count += 1
+								title_index = 0
+
+								for title in titles:
+										title_index += 1
+
+										if title == video_result.get("title"):
+												print(f"{count} duplicated title: {title} at index: {title_index}")
+
+								titles.append(video_result.get("title"))
+
+				self.assertEqual(page_count, limit, "Number of pages doesn't match.")
+
+
+if __name__ == "__main__":
 		unittest.main()

--- a/testwrapper.py
+++ b/testwrapper.py
@@ -8,7 +8,7 @@ def test_query():
     params = {}
     if len(sys.argv) < 3 :
         raise NotEnoughArgsError(
-            "SERP API requires user to put in Query and Location as command-line arguments"
+            "SerpApi requires user to put in Query and Location as command-line arguments"
         )
     params['query'] = sys.argv[1]
     params['location'] = sys.argv[2]


### PR DESCRIPTION
`start` and `num` parameters are not suitable for token-based pagination. Such pagination is used on Google Maps, YouTube, Google Scholar Authors, and other search engines.

This PR consumes URL query parameters for the next page. It stops paginating when parameters do not change.

Details: https://github.com/serpapi/google-search-results-python/issues/22

Some tests are failing because `start` and `num` parameters are not supported anymore. These tests will be fixed in the following commits.

---

Fixes #38 
Fixes #32 
Fixes #26 
Fixes #25
Fixes #22