### PR TITLE
Removed print in get_response

### DIFF
--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -55,7 +55,7 @@ class SerpApiClient(object):
         url = None
         try:
             url, parameter = self.construct_url(path)
-            print(url)
+            # print(url)
             response = requests.get(url, parameter, timeout=self.timeout)
             return response
         except requests.HTTPError as e:


### PR DESCRIPTION
Removed print in get_response. Because it prints url for every request