### PR TITLE
[Fix] `SerpApiClientException`: wrong API engine in error message

### DIFF
--- a/serpapi/apple_app_store_search.py
+++ b/serpapi/apple_app_store_search.py
@@ -17,4 +17,4 @@ class AppleAppStoreSearch(SerpApiClient):
         super(AppleAppStoreSearch, self).__init__(params_dict, APPLE_APP_STORE_ENGINE)
 
     def get_location(self, q, limit = 5):
-        raise SerpApiClientException("location is not supported by youtube search engine")
+        raise SerpApiClientException("location is not supported by Apple Search search engine")

--- a/serpapi/duck_duck_go_search.py
+++ b/serpapi/duck_duck_go_search.py
@@ -17,4 +17,4 @@ class DuckDuckGoSearch(SerpApiClient):
         super(DuckDuckGoSearch, self).__init__(params_dict, DUCKDUCKGO_ENGINE)
 
     def get_location(self, q, limit = 5):
-        raise SerpApiClientException("location is not supported by walmart search engine")
+        raise SerpApiClientException("location is not supported by DuckDuckGo search engine")

--- a/serpapi/naver_search.py
+++ b/serpapi/naver_search.py
@@ -17,4 +17,4 @@ class NaverSearch(SerpApiClient):
         super(NaverSearch, self).__init__(params_dict, NAVER_ENGINE)
 
     def get_location(self, q, limit = 5):
-        raise SerpApiClientException("location is not supported by youtube search engine")
+        raise SerpApiClientException("location is not supported by Naver search engine")


### PR DESCRIPTION
This PR contains a few small fixes that update the engine name in the error message.

Example of incorrect engine name (`walmart` -> `DuckDuckGo`):

https://github.com/serpapi/google-search-results-python/blob/ce2652b921de615262b1fd6ef82eeeb257a0386a/serpapi/duck_duck_go_search.py#L19-L20