### PR TITLE
Timeout in seconds, set timeout at GoogleSearch instantiation, add ssl_verify parameter

### DIFF
--- a/serpapi/google_search.py
+++ b/serpapi/google_search.py
@@ -10,6 +10,7 @@ class GoogleSearch(SerpApiClient):
             "location": "Austin,Texas",
         },
         timeout = 60,
+        ssl_verify = True,
     )
     data = query.get_json()
     ```
@@ -17,5 +18,5 @@ class GoogleSearch(SerpApiClient):
     https://github.com/serpapi/google-search-results-python
     """
 
-    def __init__(self, params_dict, timeout = 60):
-        super(GoogleSearch, self).__init__(params_dict, GOOGLE_ENGINE, timeout)
+    def __init__(self, params_dict, timeout = 60, ssl_verify = True):
+        super(GoogleSearch, self).__init__(params_dict, GOOGLE_ENGINE, timeout, ssl_verify)

--- a/serpapi/google_search.py
+++ b/serpapi/google_search.py
@@ -4,12 +4,18 @@ class GoogleSearch(SerpApiClient):
     """GoogleSearch enables to search google and parse the result.
     ```python
     from serpapi import GoogleSearch
-    query = GoogleSearch({"q": "coffee", "location": "Austin,Texas"})
+    query = GoogleSearch(
+        {
+            "q": "coffee",
+            "location": "Austin,Texas",
+        },
+        timeout = 60,
+    )
     data = query.get_json()
     ```
 
     https://github.com/serpapi/google-search-results-python
     """
 
-    def __init__(self, params_dict):
-        super(GoogleSearch, self).__init__(params_dict, GOOGLE_ENGINE)
+    def __init__(self, params_dict, timeout = 60):
+        super(GoogleSearch, self).__init__(params_dict, GOOGLE_ENGINE, timeout)

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -9,12 +9,15 @@ class SerpApiClient(object):
     """SerpApiClient enables to query any search engines supported by SerpApi and parse the results.
     ```python
     from serpapi import GoogleSearch
-    search = SerpApiClient({
-        "q": "Coffee", 
-        "location": "Austin,Texas", 
-        "engine": "google",
-        "api_key": "<your private key>"
-        })
+    search = SerpApiClient(
+        {
+            "q": "Coffee", 
+            "location": "Austin,Texas", 
+            "engine": "google",
+            "api_key": "<your private key>",
+        },
+        timeout = 60,
+    )
 	data = search.get_json()
     ```
 
@@ -24,7 +27,7 @@ class SerpApiClient(object):
     BACKEND = "https://serpapi.com"
     SERP_API_KEY = None
 
-    def __init__(self, params_dict, engine = None, timeout = 60000):
+    def __init__(self, params_dict, engine = None, timeout = 60):
         self.params_dict = params_dict
         self.engine = engine
         self.timeout = timeout
@@ -47,7 +50,6 @@ class SerpApiClient(object):
         url = None
         try:
             url, parameter = self.construct_url(path)
-            # print(url)
             response = requests.get(url, parameter, timeout=self.timeout)
             return response
         except requests.HTTPError as e:

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -17,6 +17,7 @@ class SerpApiClient(object):
             "api_key": "<your private key>",
         },
         timeout = 60,
+        ssl_verify = True,
     )
 	data = search.get_json()
     ```
@@ -27,10 +28,11 @@ class SerpApiClient(object):
     BACKEND = "https://serpapi.com"
     SERP_API_KEY = None
 
-    def __init__(self, params_dict, engine = None, timeout = 60):
+    def __init__(self, params_dict, engine = None, timeout = 60, ssl_verify = True):
         self.params_dict = params_dict
         self.engine = engine
         self.timeout = timeout
+        self.ssl_verify = ssl_verify
 
     def construct_url(self, path = "/search"):
         self.params_dict['source'] = 'python'
@@ -50,7 +52,7 @@ class SerpApiClient(object):
         url = None
         try:
             url, parameter = self.construct_url(path)
-            response = requests.get(url, parameter, timeout=self.timeout)
+            response = requests.get(url, parameter, timeout=self.timeout, verify=self.ssl_verify)
             return response
         except requests.HTTPError as e:
             print("fail: " + url)


### PR DESCRIPTION
This PR has three commits:

1. Timeout in the requests library is in seconds (not milliseconds). Changed default timeout to 60 seconds.
2. Fixing [issue 40](https://github.com/serpapi/google-search-results-python/issues/40) by allowing timeout to be set at GoogleSearch object instantiation.
3. Control over SSL verification parameter of the requests library at search object instantiation is a pretty useful feature, as on some networks, using `requests.get(..., verify=True)` throws SSLHandshakeError. [A problem that I, and others, face](https://stackoverflow.com/questions/42518717/system-level-solution-to-python-ssl-certificate-verify-failed). Fixed it by adding ssl_verify parameter during object instantiation.