### PR TITLE
Suggested upgrade to the SerpApiClient.get_html() method

### DIFF
--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -61,11 +61,12 @@ class SerpApiClient(object):
         """
         return self.get_response(path).text
 
-    def get_html(self, path='/search.html'):
+    def get_html(self):
         """Returns:
             Raw HTML search result from Google
         """
-        return self.get_response(path).text
+        self.params_dict["output"] = "html"
+        return self.get_results()
 
     def get_json(self):
         """Returns:

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -10,8 +10,8 @@ class SerpApiClient(object):
     ```python
     from serpapi import GoogleSearch
     search = SerpApiClient({
-        "q": "Coffee",
-        "location": "Austin,Texas",
+        "q": "Coffee", 
+        "location": "Austin,Texas", 
         "engine": "google",
         "api_key": "<your private key>"
         })
@@ -61,15 +61,11 @@ class SerpApiClient(object):
         """
         return self.get_response(path).text
 
-    def get_html(self, path='/search'):
+    def get_html(self, path='/search.html'):
         """Returns:
             Raw HTML search result from Google
         """
-        response = self.get_dictionary() # get search URL with query parameters
-        response = response['search_metadata']['raw_html_file']
-        response = requests.get(response).text
-        # print(response)
-        return response
+        return self.get_response(path).text
 
     def get_json(self):
         """Returns:
@@ -99,7 +95,7 @@ class SerpApiClient(object):
         return self.get_dictionary()
 
     def get_object(self):
-        """Returns:
+        """Returns: 
             Dynamically created python object wrapping the result data structure
         """
         # iterative over response hash
@@ -134,7 +130,7 @@ class SerpApiClient(object):
     def get_search_archive(self, search_id, format = 'json'):
         """Retrieve search result from the Search Archive API
         Parameters:
-            search_id (int): unique identifier for the search provided by metadata.id
+            search_id (int): unique identifier for the search provided by metadata.id 
             format (string): search format: json or html [optional]
         Returns:
             dict|string: search result from the archive

--- a/serpapi/serp_api_client.py
+++ b/serpapi/serp_api_client.py
@@ -10,8 +10,8 @@ class SerpApiClient(object):
     ```python
     from serpapi import GoogleSearch
     search = SerpApiClient({
-        "q": "Coffee", 
-        "location": "Austin,Texas", 
+        "q": "Coffee",
+        "location": "Austin,Texas",
         "engine": "google",
         "api_key": "<your private key>"
         })
@@ -61,11 +61,15 @@ class SerpApiClient(object):
         """
         return self.get_response(path).text
 
-    def get_html(self):
+    def get_html(self, path='/search'):
         """Returns:
             Raw HTML search result from Google
         """
-        return self.get_results()
+        response = self.get_dictionary() # get search URL with query parameters
+        response = response['search_metadata']['raw_html_file']
+        response = requests.get(response).text
+        # print(response)
+        return response
 
     def get_json(self):
         """Returns:
@@ -95,7 +99,7 @@ class SerpApiClient(object):
         return self.get_dictionary()
 
     def get_object(self):
-        """Returns: 
+        """Returns:
             Dynamically created python object wrapping the result data structure
         """
         # iterative over response hash
@@ -130,7 +134,7 @@ class SerpApiClient(object):
     def get_search_archive(self, search_id, format = 'json'):
         """Retrieve search result from the Search Archive API
         Parameters:
-            search_id (int): unique identifier for the search provided by metadata.id 
+            search_id (int): unique identifier for the search provided by metadata.id
             format (string): search format: json or html [optional]
         Returns:
             dict|string: search result from the archive
@@ -161,7 +165,7 @@ class SerpApiClient(object):
         self.params_dict["limit"] = limit
         buffer = self.get_results('/locations.json')
         return json.loads(buffer)
-    
+
     def pagination(self, start = DEFAULT_START, end = DEFAULT_END, page_size = DEFAULT_PAGE_SIZE, limit = DEFAULT_LIMIT):
         """Return:
             Generator to iterate the search results pagination

--- a/tests/test_google_search.py
+++ b/tests/test_google_search.py
@@ -60,7 +60,11 @@ class TestSearchApi(unittest.TestCase):
 				search = GoogleSearch({"q": "Coffee", "location": "Austin,Texas"})
 				data = search.get_html()
 				self.assertGreater(len(data), 10)
-				self.assertIn("<html>", data)
+				self.assertIn("<html", data)
+				
+				data = search.get_dict()
+				self.assertEqual(data["search_metadata"]["status"], "Success")
+				self.assertIsNone(data.get("error"))
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_response(self):

--- a/tests/test_google_search.py
+++ b/tests/test_google_search.py
@@ -60,6 +60,7 @@ class TestSearchApi(unittest.TestCase):
 				search = GoogleSearch({"q": "Coffee", "location": "Austin,Texas"})
 				data = search.get_html()
 				self.assertGreater(len(data), 10)
+				self.assertIn("<html>", data)
 
 		@unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
 		def test_get_response(self):


### PR DESCRIPTION
My suggestion to fix the [open issue 66](https://github.com/serpapi/google-search-results-python/issues/66).

Since the returned object from `requests.get` isn't necessarily an HTML, I approached this by accessing the JSON returned from `get_dictionary` and performing another `requests.get` on the `raw_html_file`.

Also added an assertion in `test_google_search.py` to confirm there is a `<html>` tag present in the returned data.