### PR TITLE
docs: fix KeyError in batch async searches README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ while not search_queue.empty():
 
     # retrieve search from the archive - blocker
     print(search_id + ": get search from archive")
-    search_archived = search.get_search_archive(search_id)
+    search_archived = GoogleSearch({}).get_search_archive(search_id)
     print(search_id + ": status = " +
           search_archived['search_metadata']['status'])
 


### PR DESCRIPTION
Fixes #71

The Batch Asynchronous Searches example in the README fails with `KeyError: 'search_metadata'` because `search.get_search_archive(search_id)` is called on the original `search` object, which still has all the query params from the initial search loop (including `q`, `location`, `async`, etc.).

When those params are passed to the Search Archive API, it treats them as a new search request and returns an error response like:
`{'error': 'You are using query `q` parameter on our Search Archive API...'}`

Fix: use `GoogleSearch({}).get_search_archive(search_id)` instead, which is already the pattern shown correctly in the Search Archive API section of this same README.